### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Liniting using Eslint
+permissions:
+    contents: read
 
 on:
     pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/jellyfish/security/code-scanning/2](https://github.com/dezh-tech/jellyfish/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a linting workflow that only reads the repository's contents, we will set `contents: read` as the minimal required permission. This ensures the workflow has only the permissions it needs and no unnecessary write access.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
